### PR TITLE
Support templateUrl in directive $compile options

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -9,7 +9,9 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "chai-jquery": "^1.2.3",
+    "event-stream": "^3.3.2",
     "gulp": "^3.8.7",
+    "gulp-angular-templatecache": "^1.8.0",
     "gulp-concat": "^2.3.4",
     "gulp-jshint": "^1.8.4",
     "gulp-plumber": "^0.6.6",
@@ -23,10 +25,12 @@
     "karma-jasmine": "^0.1.5",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.1.8",
+    "karma-ng-html2js-preprocessor": "^0.2.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.2.0",
     "karma-spec-reporter": "^0.0.18",
     "mocha": "^1.21.4",
+    "ng-html2js": "^2.0.0",
     "run-sequence": "^1.0.2",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.5.0"

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -7,6 +7,8 @@ var path = require('path');
 var plumber = require('gulp-plumber');
 var runSequence = require('run-sequence');
 var jshint = require('gulp-jshint');
+var templateCache = require('gulp-angular-templatecache');
+var eventStream = require('event-stream');
 
 /**
  * File patterns
@@ -27,14 +29,26 @@ var sourceFiles = [
   path.join(sourceDirectory, '/**/*.js')
 ];
 
+var templates = [
+  path.join(sourceDirectory, '/**/*.tpl.html')
+];
+
 var lintFiles = [
   'gulpfile.js',
   // Karma configuration
   'karma-*.conf.js'
 ].concat(sourceFiles);
 
+function getTemplateCache() {
+  return gulp.src(templates)
+    .pipe(plumber())
+    .pipe(templateCache({
+      module: '<%= config.yourModule.slugified %>.directives'
+    }));
+}
+
 gulp.task('build', function() {
-  gulp.src(sourceFiles)
+  return eventStream.merge(gulp.src(sourceFiles), getTemplateCache())
     .pipe(plumber())
     .pipe(concat('<%= config.yourModule.slugified %>.js'))
     .pipe(gulp.dest('./dist/'))
@@ -54,9 +68,7 @@ gulp.task('process-all', function (done) {
  * Watch task
  */
 gulp.task('watch', function () {
-
-  // Watch JavaScript files
-  gulp.watch(sourceFiles, ['process-all']);
+  gulp.watch([sourceFiles, templates], ['process-all']);
 });
 
 /**

--- a/generators/directive/index.js
+++ b/generators/directive/index.js
@@ -105,7 +105,11 @@ var DirectiveGenerator = yeoman.generators.NamedBase.extend({
   },
 
   renderDirectiveFile: function() {
-    this.template('directive.js', 'modules/' + this.slugifiedModuleName + '/directives/' + this.slugifiedName + '.directive.js')
+    this.template('directive.js', 'modules/' + this.slugifiedModuleName + '/directives/' + this.slugifiedName + '.directive.js');
+  },
+
+  renderTemplateFile: function() {
+    this.template('directive.js', 'modules/' + this.slugifiedModuleName + '/directives/' + this.slugifiedName + '.tpl.html');
   }
 });
 

--- a/generators/directive/templates/directive.js
+++ b/generators/directive/templates/directive.js
@@ -5,7 +5,8 @@
 angular.module('<%= slugifiedModuleName %>').directive('<%= camelizedName %>', [
   function() {
     return {
-      template: '<div></div>',
+      //template: '<div></div>',
+      templateUrl: '/modules/<%= slugifiedModuleName %>/directives/<%= slugifiedName %>/<%= slugifiedName %>.tpl.html'
       restrict: '<%= restrict %>',
       replace: <%= replaceContent %>,
       scope: <% if (scopeType == 'parent') {%> false <%} else if (scopeType == 'child') {%> true <%} else if (scopeType == 'isolated') {%>{}<%}%>,


### PR DESCRIPTION
This required installing several modules for converting HTML templates into Javascript strings, then saving them to an Angular template-cache, then merging the file containing the template-cache initialization with the the rest of the single file package downloadable.
